### PR TITLE
Fixed an Issue Where Image Quality Was Bad

### DIFF
--- a/image_titler/trc_image_titler.py
+++ b/image_titler/trc_image_titler.py
@@ -147,7 +147,7 @@ def save_copy(og_image: Image, edited_image: Image, title: str, output_path: str
         storage_path = f'{file_name}-{tag}.{og_image.format}'
     else:
         storage_path = f'{output_path}{os.sep}{file_name}-{tag}.{og_image.format}'
-    edited_image.save(storage_path)
+    edited_image.save(storage_path, subsampling=0, quality=100)  # Improved quality
 
 
 def main():

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="image-titler",
-    version="1.5.0",
+    version="1.5.1",
     author="The Renegade Coder",
     author_email="jeremy.grifski@therenegadecoder.com",
     description="Adds a title to an image using The Renegade Coder Featured Image style",

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     url="https://github.com/TheRenegadeCoder/image-titler",
     packages=setuptools.find_packages(),
-    include_package_data = True,
+    include_package_data=True,
     entry_points={
         "console_scripts": [
             'image_titler = image_titler.trc_image_titler:main',


### PR DESCRIPTION
Apparently, for as long as I have been using this tool, the files were being saved in low quality. I never noticed because the previews were crystal clear. Honestly, I thought the dip in quality was due to WordPress. Well, that's now fixed. 

Here's an example of the current quality:

![6-ways-to-format-a-string-in-python-featured-image](https://user-images.githubusercontent.com/11050412/72209151-62b5f300-3479-11ea-8714-9c86ffd57779.JPEG)

Here's what images used to look like:

![6-ways-to-format-a-string-in-python-featured-image](https://user-images.githubusercontent.com/11050412/72209160-75302c80-3479-11ea-855d-ac7ad0a8f60e.JPEG)

It may be subtle, but the colors are distorted in the second image. Specifically, I'm looking at the reds in the title bars. Yuck! 👎 