### PR TITLE
Added Program Version Tag to File Names

### DIFF
--- a/image_titler/trc_image_titler.py
+++ b/image_titler/trc_image_titler.py
@@ -1,13 +1,14 @@
 import argparse
 import os
 import tkinter
-from tkinter.filedialog import askopenfilename
 from pathlib import Path
-from titlecase import titlecase
+from tkinter.filedialog import askopenfilename
 
+import pkg_resources
 from PIL import Image
 from PIL import ImageDraw
 from PIL import ImageFont
+from titlecase import titlecase
 
 FONT = os.path.join(os.path.dirname(__file__), "BERNHC.TTF")
 TEXT_FILL = (255, 255, 255)
@@ -143,10 +144,11 @@ def save_copy(og_image: Image, edited_image: Image, title: str, output_path: str
     """
     file_name = title.lower().replace(" ", "-")
     tag = "featured-image"
+    version = pkg_resources.require("image-titler")[0].version
     if output_path is None:
-        storage_path = f'{file_name}-{tag}.{og_image.format}'
+        storage_path = f'{file_name}-{tag}-v{version}.{og_image.format}'
     else:
-        storage_path = f'{output_path}{os.sep}{file_name}-{tag}.{og_image.format}'
+        storage_path = f'{output_path}{os.sep}{file_name}-{tag}-v{version}.{og_image.format}'
     edited_image.save(storage_path, subsampling=0, quality=100)  # Improved quality
 
 

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setuptools.setup(
     version="1.6.0",
     author="The Renegade Coder",
     author_email="jeremy.grifski@therenegadecoder.com",
-    description="Adds a title to an image using The Renegade Coder Featured Image style",
+    description="Adds a title and logo to an image using The Renegade Coder Featured Image style",
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/TheRenegadeCoder/image-titler",

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="image-titler",
-    version="1.5.2",
+    version="1.5.3",
     author="The Renegade Coder",
     author_email="jeremy.grifski@therenegadecoder.com",
     description="Adds a title to an image using The Renegade Coder Featured Image style",

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="image-titler",
-    version="1.5.3",
+    version="1.6.0",
     author="The Renegade Coder",
     author_email="jeremy.grifski@therenegadecoder.com",
     description="Adds a title to an image using The Renegade Coder Featured Image style",


### PR DESCRIPTION
The rationale behind this change is a bit selfish. I have a website which I generate featured images for. Sometimes, I need to regenerate featured images—usually when I upgrade the software. For example, I am now going through and generating new featured images for all of my source images because [I added logo support in v1.5.0](https://github.com/TheRenegadeCoder/image-titler/releases/tag/v1.5.0). The problem is the file names clash when I replace the featured images, so I figured adding some metadata to the file name would make the process a bit smoother. Also, labeling files this way makes it easier to trace which version of the code actually generated that image. 